### PR TITLE
feat: Add capture_screenshot tool with vision model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ MCP-Slicer connects 3D Slicer with model clients like Claude Desktop or Cline th
 
 ## Features
 
-1. list_nodes: List and filter Slicer MRML nodes and view their properties
+1. **list_nodes**: List and filter Slicer MRML nodes and view their properties
 
-2. execute_python_code: Execute Python code in the Slicer environment
+2. **execute_python_code**: Execute Python code in the Slicer environment
+
+3. **capture_screenshot**: Capture real-time screenshots of Slicer views
+   - Full application window (including module panels)
+   - Individual slice views (Red/Yellow/Green)
+   - 3D rendering view
+   - Enables complete REACT loop with visual feedback
 
 ## Installation
 
@@ -105,6 +111,20 @@ Make sure you see the corresponding slicer tools added to the Claude Desktop App
 > Draw a translucent green cube of 8 cm in the Slicer scene, mark its vertices, and then draw a red sphere inscribed in it.
 
 <img width="1045" alt="example_code_execute_en" src="https://github.com/zhaoyouj/mcp-slicer/blob/main/docs/images/example_code_execute_en.png?raw=true" />
+
+### - capture_screenshot
+
+> Capture the current state of Slicer to provide visual feedback to AI
+
+**Usage examples:**
+- `capture_screenshot()` - Capture full application window
+- `capture_screenshot(view_type="slice", view_name="red")` - Capture Red slice view
+- `capture_screenshot(view_type="3d", camera_axis="A")` - Capture 3D view from anterior
+
+This enables a complete REACT loop where AI can:
+1. **Reason** about what to do
+2. **Act** using `execute_python_code`
+3. **Observe** the result using `capture_screenshot`
 
 ## Technical Details
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,9 +12,15 @@ MCP-Slicer 通过模型上下文协议(MCP)将 3D Slicer 与 例如 Claude Deskt
 
 ## 功能
 
-1. list_nodes: 用于列出和过滤 Slicer MRML 节点并查看其属性
+1. **list_nodes**: 用于列出和过滤 Slicer MRML 节点并查看其属性
 
-2. execute_python_code: 允许在 Slicer 环境中执行 Python 代码
+2. **execute_python_code**: 允许在 Slicer 环境中执行 Python 代码
+
+3. **capture_screenshot**: 实时捕获 Slicer 视图截图
+   - 完整应用窗口（包括模块面板）
+   - 单独的切片视图（Red/Yellow/Green）
+   - 3D 渲染视图
+   - 实现完整的 REACT 循环，提供视觉反馈
 
 ## 安装
 
@@ -102,6 +108,20 @@ Go to Claude > Settings > Developer > Edit Config > claude_desktop_config.json t
 > 在 Slicer 场景中绘制一个 8cm 的半透明绿色立方体，标出它的顶点，再在其中画一个内切的红色球体
 
 <img width="1045" alt="example_code_execute_en" src="https://github.com/zhaoyouj/mcp-slicer/blob/main/docs/images/example_code_execute_cn.png?raw=true" />
+
+### - capture_screenshot
+
+> 捕获 Slicer 当前状态，为 AI 提供视觉反馈
+
+**使用示例：**
+- `capture_screenshot()` - 捕获完整应用窗口
+- `capture_screenshot(view_type="slice", view_name="red")` - 捕获 Red 切片视图
+- `capture_screenshot(view_type="3d", camera_axis="A")` - 从前方捕获 3D 视图
+
+这实现了完整的 REACT 循环，AI 可以：
+1. **推理**（Reason）要做什么
+2. **行动**（Act）使用 `execute_python_code`
+3. **观察**（Observe）使用 `capture_screenshot` 查看结果
 
 ## 技术细节
 

--- a/src/mcp_slicer/mcp_server.py
+++ b/src/mcp_slicer/mcp_server.py
@@ -268,5 +268,3 @@ def capture_screenshot(
         return [TextContent(type="text", text=f"Connection error: {str(e)}. Make sure Slicer Web Server is running.")]
     except Exception as e:
         return [TextContent(type="text", text=f"Error: {str(e)}")]
-    except Exception as e:
-        return [{"type": "text", "text": f"Screenshot capture failed: {str(e)}"}]

--- a/src/mcp_slicer/mcp_server.py
+++ b/src/mcp_slicer/mcp_server.py
@@ -1,7 +1,9 @@
 # server.py
 from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent, ImageContent
 import requests
 import json
+import base64
 
 # Create an MCP server
 mcp = FastMCP("SlicerMCP")
@@ -145,3 +147,126 @@ def execute_python_code(code: str) -> dict:
             "success": False,
             "message": f"Connection error: {str(e)}"
             }
+
+
+# Add capture_screenshot tool
+@mcp.tool()
+def capture_screenshot(
+    view_type: str = "application",
+    view_name: str = None,
+    slice_offset: float = None,
+    slice_orientation: str = None,
+    camera_axis: str = None,
+    image_size: int = None
+) -> list:
+    """
+    Capture a screenshot from 3D Slicer's views.
+
+    This tool provides real-time visual feedback of the current state of Slicer,
+    enabling AI to observe the GUI and make informed decisions in a complete REACT loop.
+
+    Parameters:
+    view_type (str): Type of screenshot to capture. Options:
+        - "application" (default): Full application window including all panels and views
+        - "slice": A specific slice view (Red/Yellow/Green)
+        - "3d": The 3D rendering view
+    
+    view_name (str): For slice views, specify which view to capture.
+        Options: "red", "yellow", "green"
+        Only used when view_type="slice"
+    
+    slice_offset (float): For slice views, offset in mm relative to slice origin.
+        Only used when view_type="slice"
+    
+    slice_orientation (str): For slice views, specify orientation.
+        Options: "axial", "sagittal", "coronal"
+        Only used when view_type="slice"
+    
+    camera_axis (str): For 3D views, specify camera view direction.
+        Options: "L" (Left), "R" (Right), "A" (Anterior), "P" (Posterior), 
+                 "I" (Inferior), "S" (Superior)
+        Only used when view_type="3d"
+    
+    image_size (int): Pixel size of output image (for slice and 3D views).
+        Only used when view_type="slice" or view_type="3d"
+
+    Returns:
+        A list containing text and/or image content. The image is returned
+        in MCP's standard format for proper display in AI clients.
+
+    Examples:
+    - Capture full application: {"tool": "capture_screenshot", "arguments": {"view_type": "application"}}
+    - Capture Red slice view: {"tool": "capture_screenshot", "arguments": {"view_type": "slice", "view_name": "red"}}
+    - Capture 3D view from anterior: {"tool": "capture_screenshot", "arguments": {"view_type": "3d", "camera_axis": "A"}}
+    - Capture axial slice: {"tool": "capture_screenshot", "arguments": {"view_type": "slice", "view_name": "red", "slice_orientation": "axial"}}
+    """
+    try:
+        # Determine the API endpoint based on view_type
+        if view_type == "application":
+            api_url = f"{SLICER_WEB_SERVER_URL}/screenshot"
+            params = {}
+            description = "full application window"
+            
+        elif view_type == "slice":
+            if not view_name:
+                return [TextContent(type="text", text="Error: view_name is required for slice screenshots (red, yellow, or green)")]
+            
+            api_url = f"{SLICER_WEB_SERVER_URL}/slice"
+            params = {"view": view_name.lower()}
+            description = f"{view_name} slice view"
+            
+            # Add optional parameters
+            if slice_offset is not None:
+                params["offset"] = slice_offset
+            if slice_orientation:
+                params["orientation"] = slice_orientation.lower()
+                description += f" ({slice_orientation})"
+            if image_size:
+                params["size"] = image_size
+                
+        elif view_type == "3d":
+            api_url = f"{SLICER_WEB_SERVER_URL}/threeD"
+            params = {}
+            description = "3D view"
+            
+            # Add optional parameters
+            if camera_axis:
+                params["lookFromAxis"] = camera_axis.upper()
+                description += f" from {camera_axis} axis"
+                
+        else:
+            return [TextContent(type="text", text=f"Error: Invalid view_type '{view_type}'. Must be 'application', 'slice', or '3d'")]
+
+        # Make the request to Slicer Web Server
+        response = requests.get(api_url, params=params)
+        response.raise_for_status()
+        
+        # Check if response is an image
+        if response.headers.get('Content-Type', '').startswith('image/'):
+            # Convert image bytes to base64
+            image_base64 = base64.b64encode(response.content).decode('utf-8')
+            
+            # Return using MCP's content types
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Screenshot of {description} captured successfully"
+                ),
+                ImageContent(
+                    type="image",
+                    data=image_base64,
+                    mimeType="image/png"
+                )
+            ]
+        else:
+            # Unexpected response type
+            return [TextContent(type="text", text=f"Error: Unexpected response type: {response.headers.get('Content-Type')}")]
+            
+    except requests.exceptions.HTTPError as e:
+        return [TextContent(type="text", text=f"HTTP Error {e.response.status_code}: {str(e)}")]
+    except requests.exceptions.RequestException as e:
+        return [TextContent(type="text", text=f"Connection error: {str(e)}. Make sure Slicer Web Server is running.")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {str(e)}")]
+    except Exception as e:
+        return [{"type": "text", "text": f"Screenshot capture failed: {str(e)}"}]


### PR DESCRIPTION
Add new capture_screenshot tool that enables AI to observe Slicer's visual state in real-time, completing the REACT loop:

Features:
- Capture full application window with all panels
- Capture individual slice views (Red/Yellow/Green)
- Capture 3D rendering view with camera positioning
- Support for slice orientation and offset control
- Returns images using MCP standard ImageContent type
- Enables vision models to analyze Slicer's GUI state

This allows AI to:
1. Reason about what actions to take
2. Act using execute_python_code
3. Observe results using capture_screenshot

Technical implementation:
- Uses Slicer Web Server screenshot/slice/threeD APIs
- Encodes images as base64 PNG
- Returns TextContent and ImageContent objects
- Properly triggers vision capabilities in AI clients